### PR TITLE
Build fixes and other tweaks

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ EXEEXT=$(OBJEXEEXT)
 bin_PROGRAMS                   =
 lib_LIBRARIES                  =
 
-libt9p_a_SOURCES               = t9p.c t9p_rtems.c t9proto.c t9p_posix.c
+libt9p_a_SOURCES               = t9p.c t9p_rtems.c t9proto.c t9p_posix.c t9p_mem.c
 EXTRA_libt9p_a_SOURCES         = t9p.modini.c
 
 lib_LIBRARIES                 += libt9p.a

--- a/src/t9p.c
+++ b/src/t9p.c
@@ -926,11 +926,7 @@ void
 t9p_opts_init(struct t9p_opts* opts)
 {
   memset(opts, 0, sizeof(*opts));
-#ifdef __mcoldfire__
-  opts->msize = 4096; /* Coldfire works better with smaller msize */
-#else
   opts->msize = 65536;
-#endif
   opts->queue_size = T9P_PACKET_QUEUE_SIZE;
   opts->max_fids = DEFAULT_MAX_FILES;
   opts->send_timeo = DEFAULT_SEND_TIMEO;

--- a/src/t9p.c
+++ b/src/t9p.c
@@ -369,7 +369,7 @@ tr_pool_init(struct trans_pool* q, uint32_t num)
 {
   memset(q, 0, sizeof(*q));
 
-  q->queue = msg_queue_create("T9PQ", sizeof(struct trans_node*), MAX_TRANSACTIONS);
+  q->queue = msg_queue_create("T9PQ", sizeof(struct trans_node*), num);
   if (!q->queue)
     return -1;
 
@@ -1006,7 +1006,12 @@ t9p_init(
     goto error_post_fhl;
   }
 
-  if (tr_pool_init(&c->trans_pool, MAX_TRANSACTIONS) < 0) {
+  /* When running in single thread mode, we don't need that many transactions */
+  size_t max_trans = MAX_TRANSACTIONS;
+  if (opts->mode == T9P_THREAD_MODE_NONE)
+    max_trans = 16;
+
+  if (tr_pool_init(&c->trans_pool, max_trans) < 0) {
     ERRLOG("Unable to create transaction pool\n");
     goto error_post_fhl;
   }

--- a/src/t9p.h
+++ b/src/t9p.h
@@ -135,6 +135,8 @@ typedef struct T9P_ALIGNED(4) t9p_stats {
   uint32_t recv_errs;
   uint32_t total_bytes_send;
   uint32_t total_bytes_recv;
+  uint32_t used_fids;
+  uint32_t total_fids;
   uint32_t msg_counts[128]; /** 128 must match Tmax in t9proto.h */
 } t9p_stats_t;
 

--- a/src/t9p_mem.c
+++ b/src/t9p_mem.c
@@ -20,6 +20,26 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __rtems__
+#include <rtems/score/protectedheap.h>
+#endif
+
+#if __RTEMS_MAJOR__ < 7
+extern Heap_Control* RTEMS_Malloc_Heap;
+
+static size_t
+t9p__malloc_usable_size(void* ptr)
+{
+  if (!ptr) return 0;
+
+  size_t sz = 0;
+  _Protected_heap_Get_block_size(RTEMS_Malloc_Heap, ptr, &sz);
+
+  return sz;
+}
+#define malloc_usable_size t9p__malloc_usable_size
+#endif
+
 void*
 #if defined(__GNUC__) || defined(__clang__)
 __attribute__((malloc, alloc_size(1)))

--- a/src/t9p_rtems.c
+++ b/src/t9p_rtems.c
@@ -489,16 +489,38 @@ t9p_iterate_fs_stats(const rtems_filesystem_mount_table_entry_t* mt_entry, void*
   t9p_opts_t opts = t9p_get_opts(fsi->c);
   t9p_stats_t stats = t9p_get_stats(fsi->c);
   printf("%s\n", fsi->opts.ip);
-  printf("  apath=%s,mntpt=%s,uid=%d,gid=%d\n", fsi->apath, mt_entry->target,
-    (int)opts.uid, (int)opts.gid);
-  printf("   msize=%u\n", (unsigned)t9p_get_msize(fsi->c));
-  printf("   bytesSent=%u (%.2fM) bytesRecv=%u (%.2fM)\n",
+  printf(
+    "  apath=%s,mntpt=%s,uid=%d,gid=%d\n",
+    fsi->apath,
+    mt_entry->target,
+    (int)opts.uid,
+    (int)opts.gid
+  );
+  printf(
+    "   msize=%u\n",
+    (unsigned)t9p_get_msize(fsi->c)
+  );
+  printf(
+    "   bytesSent=%u (%.2fM) bytesRecv=%u (%.2fM)\n",
     (unsigned)stats.total_bytes_send, stats.total_bytes_send / 1000000.f,
-    (unsigned)stats.total_bytes_recv, stats.total_bytes_recv / 1000000.f);
-  printf("   sendCnt=%u, sendErrCnt=%u\n", (unsigned)stats.send_cnt,
-    (unsigned)stats.send_errs);
-  printf("   recvCnt=%u, recvErrCnt=%u\n\n", (unsigned)stats.recv_cnt,
-  (unsigned)stats.recv_errs);
+    (unsigned)stats.total_bytes_recv, stats.total_bytes_recv / 1000000.f
+  );
+  printf(
+    "   sendCnt=%u, sendErrCnt=%u\n",
+    (unsigned)stats.send_cnt,
+    (unsigned)stats.send_errs
+  );
+  printf(
+    "   recvCnt=%u, recvErrCnt=%u\n",
+    (unsigned)stats.recv_cnt,
+    (unsigned)stats.recv_errs
+  );
+  printf(
+    "   totalFids=%u, usedFids=%u (%.2f%%)\n\n",
+    (unsigned)stats.total_fids,
+    (unsigned)stats.used_fids,
+    stats.used_fids / (float)(stats.total_fids)
+  );
 
   (*n)++;
   return false;
@@ -542,16 +564,23 @@ int
 p9MemStatsGlobal()
 {
 #ifndef T9P_NO_MEMTRACK
+  uint32_t alloc_bytes = atomic_load_u32(&g_t9p_memtrack_ctx.total_allocd_bytes);
+  uint32_t free_bytes = atomic_load_u32(&g_t9p_memtrack_ctx.total_freed_bytes);
   printf(
     "Allocations: %d (%u bytes total, %u bytes requested)\n",
-    atomic_load_u32(&g_t9p_memtrack_ctx.total_alloc_calls),
-    atomic_load_u32(&g_t9p_memtrack_ctx.total_allocd_bytes),
-    atomic_load_u32(&g_t9p_memtrack_ctx.total_allocd_bytes_requested)
+    (int)atomic_load_u32(&g_t9p_memtrack_ctx.total_alloc_calls),
+    (unsigned)alloc_bytes,
+    (unsigned)atomic_load_u32(&g_t9p_memtrack_ctx.total_allocd_bytes_requested)
   );
   printf(
     "Frees:       %d (%u bytes total)\n",
-    atomic_load_u32(&g_t9p_memtrack_ctx.total_free_calls),
-    atomic_load_u32(&g_t9p_memtrack_ctx.total_freed_bytes)
+    (int)atomic_load_u32(&g_t9p_memtrack_ctx.total_free_calls),
+    (unsigned)free_bytes
+  );
+  printf(
+    "Used:        %u bytes (%.2f KiB)\n",
+    (unsigned)(alloc_bytes - free_bytes),
+    (alloc_bytes - free_bytes) / 1024.f
   );
 #else
   printf("Compiled with NO_MEMTRACK, no stats have been recorded!");

--- a/src/t9p_rtems.c
+++ b/src/t9p_rtems.c
@@ -720,7 +720,7 @@ t9p_rtems_fsmount_me(rtems_filesystem_mount_table_entry_t* mt_entry, const void*
     return -1;
   }
 
-  int loglevel = T9P_LOG_DEBUG;
+  int loglevel = T9P_LOG_WARN;
   t9p_thread_mode_t thr_mode = T9P_THREAD_MODE_NONE;
   for (char* r = strtok(buf, ","); r; r = strtok(NULL, ",")) {
     if (!strncmp(r, "ip", strlen("ip"))) {


### PR DESCRIPTION
* Added a "balance" to the mem tracking output
* Fixed build error due to t9p_mem.c not being in Makefile.am (oops)
* Undo previous changes to msize for CF. 64k seems to work okay.
* Use local impl of malloc_usable_size if not provided by RTEMS