### PR TITLE
Fix path traversal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "RTEMS")
     configure_file(tests/rtems_test_cfg.h.in ${CMAKE_CURRENT_BINARY_DIR}/rtems_test_cfg.h)
 
     # RTEMS test code
-    add_executable(
+    rtems_add_simple_executable(
         t9p_rtems_test
         "tests/t9p_rtems_test.c"
         "tests/t9p_cmd.c"
@@ -60,9 +60,10 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "RTEMS")
     target_link_libraries(
         t9p_rtems_test PRIVATE
         t9p
+        m
+        c
         rtemsbsp
         rtemscpu
-        m
     )
 
     if ("${RTEMS_NETWORK_STACK}" STREQUAL "BSD")
@@ -72,6 +73,7 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "RTEMS")
             bsd
             debugger
             m
+            c
         )
     endif()
 

--- a/src/t9p.h
+++ b/src/t9p.h
@@ -689,6 +689,13 @@ t9p_opts_t t9p_get_opts(t9p_context_t* c);
  */
 struct t9p_stats t9p_get_stats(t9p_context_t* c);
 
+/**
+ * Returns the path of the node relative to the root
+ * \param h Handle
+ * \returns A null terminated string representing the path
+ */
+const char* t9p_get_path(t9p_handle_t h);
+
 /** Returns TRUE if the handle is the root, FALSE otherwise */
 int t9p_is_root(t9p_context_t* c, t9p_handle_t h);
 


### PR DESCRIPTION
We were previously incorrectly traversing paths. RTEMS will issue us completely arbitrary paths, including . and .. (which are used to compute cwd). If we don't properly traverse the file tree (and mount points), bad things happen.

Also fixes an issue with d_ino and st_dev not being set.