### PR TITLE
t9p: enable TCP_NODELAY only when we need it

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,35 @@
 t9p is a relatively small (originally tiny) 9p2000.L client supporting RTEMS and Linux.
 This client was designed with older RTEMS systems in mind (single core, <=512M memory, PowerPC or m68k).
 
+t9p has been tested on the following platforms:
+- Linux x86\_64
+- mvme6100 (PowerPC G4, 512MB memory) RTEMS 4.10.2
+- mvme3100 (PowerPC e500, 256MB memory) RTEMS 4.10.2
+- uC5282 (Coldfire [m68k] V2, 16MB memory) RTEMS 4.10.2
+- pc686 (i386 in Qemu) RTEMS 4.10.2
+
 ## Building
+
+A C99 compliant compiler and CMake are required.
 
 ### Integrating with Other Projects
 
-t9p's source files require no special defines or include dirs to build, so they can be trivially included in other projects in a variety of ways.
+t9p's source files require no special compiler flags to build, so they can be trivially included in other projects.
 
-Platform specific source files will need to be excluded manually (i.e. do not build t9p_rtems.c if you are targeting Linux).
+Platform specific source files will need to be excluded manually (i.e. do not build `t9p_rtems.c` if you are targeting Linux).
 
 ### Configuring
 
-A makefile is provided that can automatically configure for all targets.
+A makefile is provided that can automatically configure for all targets. This is particularly handy when cross compiling for
+multiple targets.
 ```sh
 make -f Makefile.conf configure
 ```
 
-If the RTEMS_TOP environment variable is set to the top of your RTEMS 6 install, Makefile.conf will automatically determine the available targets
+If the `RTEMS_TOP` environment variable is set to the top of your RTEMS 6+ install, Makefile.conf will automatically determine the available targets
 and configure for those.
 
-The build-cmake directory will contain all of the build subdirs. It is safe to delete.
+The build files will be generated into the `build-cmake` directory. This directory is safe to delete.
 
 ### Building All
 

--- a/src/t9p.c
+++ b/src/t9p.c
@@ -3458,6 +3458,7 @@ static int
 tr_send_now(struct t9p_context* c, struct trans_node* n)
 {
   ssize_t l;
+  int err = 0;
 
   /* Debugging */
   if (c->opts.log_level <= T9P_LOG_TRACE) {
@@ -3472,6 +3473,10 @@ tr_send_now(struct t9p_context* c, struct trans_node* n)
   }
 log_done:
 
+  /* Enables TCP_NODELAY for performance reasons (especially on RTEMS...) */
+  if (n->tr.hdata)
+    c->trans.batch(c->conn, 1);
+
   /* Send header data, if any */
   if (n->tr.hdata) {
     if ((l = c->trans.send(c->conn, n->tr.hdata, n->tr.hsize, 0)) < 0) {
@@ -3479,7 +3484,8 @@ log_done:
       ERROR(c, "send: %s\n", strerror(-l));
       if (l == -EPIPE)
         t9p__conn_broken(c);
-      return -1;
+      err = -1;
+      goto error;
     }
     atomic_add_u32(&c->stats.send_cnt, 1);
     atomic_add_u32(&c->stats.total_bytes_send, n->tr.hsize);
@@ -3492,12 +3498,17 @@ log_done:
       ERROR(c, "send: %s\n", strerror(-l));
       if (l == -EPIPE)
         t9p__conn_broken(c);
-      return -1;
+      err = -1;
+      goto error;
     }
     atomic_add_u32(&c->stats.send_cnt, 1);
     atomic_add_u32(&c->stats.total_bytes_send, n->tr.size);
   }
-  return 0;
+
+error:
+  if (n->tr.hdata)
+    c->trans.batch(c->conn, 0);
+  return err;
 }
 
 static int
@@ -3647,16 +3658,6 @@ t9p__tcp_newsock(int need_nonblock)
     perror("setsockopt");
   }
 #endif
-
-#ifdef __rtems__
-  /* With the 4.4BSD networking stack, packing data into the same TCP segment
-   * seems exceptionally slow (I'm seeing delays on the order of milliseconds
-   * in write perf tests). Need to compare behavior with Linux */
-  int opt = 1;
-  if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt)) < 0) {
-    perror("setsockopt");
-  }
-#endif
   
 #ifdef __linux__
   if (need_nonblock) {
@@ -3674,7 +3675,7 @@ t9p__tcp_newsock(int need_nonblock)
   return sock;
 }
 
-void*
+static void*
 t9p_tcp_init(t9p_context_t* c)
 {
   struct tcp_context* ctx = t9p_calloc(1, sizeof(struct tcp_context));
@@ -3704,7 +3705,7 @@ t9p_tcp_init(t9p_context_t* c)
   return ctx;
 }
 
-int
+static int
 t9p_tcp_disconnect(void* context)
 {
   struct tcp_context* ctx = context;
@@ -3763,7 +3764,7 @@ t9p_tcp_connect(void* context, const char* addr_or_file)
   return 0;
 }
 
-int
+static int
 t9p_tcp_reconnect(void* context, const char* addr_or_file)
 {
   struct tcp_context* ctx = context;
@@ -3778,7 +3779,7 @@ t9p_tcp_reconnect(void* context, const char* addr_or_file)
   return t9p_tcp_connect(context, addr_or_file);
 }
 
-void
+static void
 t9p_tcp_shutdown(void* context)
 {
   struct tcp_context* ctx = context;
@@ -3786,14 +3787,14 @@ t9p_tcp_shutdown(void* context)
   t9p_free(context);
 }
 
-ssize_t
+static ssize_t
 t9p_tcp_send(void* context, const void* data, size_t len, int flags)
 {
   struct tcp_context* pc = context;
   return send(pc->sock, data, len, flags);
 }
 
-ssize_t
+static ssize_t
 t9p_tcp_recv(void* context, void* data, size_t len, int flags)
 {
   int rflags = 0;
@@ -3865,14 +3866,15 @@ t9p_tcp_recv(void* context, void* data, size_t len, int flags)
   return off;
 }
 
-int
+static int
 t9p_tcp_getsock(void* context)
 {
   struct tcp_context* c = context;
   return c->sock;
 }
 
-int t9p_tcp_data_avail(void* context)
+static int
+t9p_tcp_data_avail(void* context)
 {
   struct tcp_context* c = context;
   fd_set fs;
@@ -3882,6 +3884,23 @@ int t9p_tcp_data_avail(void* context)
   struct timeval to = {0};
   select(1, &fs, NULL, NULL, &to);
   return !!FD_ISSET(c->sock, &fs);
+}
+
+static int
+t9p_tcp_batch(void* context, int en)
+{
+  struct tcp_context* c = context;
+
+  /* Enable NODELAY when batching requests to reduce latency between
+   * subsequent segment sends. Without this, I'm seeing delays on the order
+   * of milliseconds with the 4.4BSD derived network stack for RTEMS */
+  int opt = en;
+  int ret;
+  if ((ret = setsockopt(c->sock, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt))) < 0) {
+    perror("setsockopt");
+    return ret;
+  }
+  return 0;
 }
 
 #endif
@@ -3899,6 +3918,7 @@ t9p_init_tcp_transport(t9p_transport_t* tp)
   tp->getsock = t9p_tcp_getsock;
   tp->reconnect = t9p_tcp_reconnect;
   tp->avail = t9p_tcp_data_avail;
+  tp->batch = t9p_tcp_batch;
   return 0;
 #else
   return -1;

--- a/src/t9p.h
+++ b/src/t9p.h
@@ -85,18 +85,16 @@ typedef enum t9p_qid_type
 /**
  * Transport methods.
  */
-typedef void* (*t9p_init_t)(t9p_context_t* /*t9p_context*/);
-typedef void (*t9p_shutdown_t)(void* /*context*/);
-typedef int (*t9p_connect_t)(void* /*context*/, const char* /*addr_or_file*/);
-/** Disconnect method, return 0 for success */
-typedef int (*t9p_disconnect_t)(void* /*context*/);
-typedef ssize_t (*t9p_send_t)(
-  void* /*context*/, const void* /*data*/, size_t /*len*/, int /*flags*/
-);
-typedef ssize_t (*t9p_recv_t)(void* /*context*/, void* /*data*/, size_t /*len*/, int /*flags*/);
-typedef int (*t9p_get_sock_t)(void* /*context*/);
-typedef int (*t9p_reconnect_t)(void* /*context*/, const char* /*addr_or_file*/);
-typedef int (*t9p_data_avail_t)(void* /*context*/);
+typedef void*   (*t9p_init_t)(t9p_context_t* ctx);
+typedef void    (*t9p_shutdown_t)(void* ctx);
+typedef int     (*t9p_connect_t)(void* ctx, const char* addr_or_file);
+typedef int     (*t9p_disconnect_t)(void* ctx);
+typedef ssize_t (*t9p_send_t)(void* ctx, const void* data, size_t len, int flags);
+typedef ssize_t (*t9p_recv_t)(void* ctx, void* data, size_t len, int flags);
+typedef int     (*t9p_get_sock_t)(void* ctx);
+typedef int     (*t9p_reconnect_t)(void* ctx, const char* addr_or_file);
+typedef int     (*t9p_data_avail_t)(void* ctx);
+typedef int     (*t9p_batch_t)(void* ctx, int enable);
 
 /**
  * Transport interface.
@@ -105,7 +103,8 @@ typedef int (*t9p_data_avail_t)(void* /*context*/);
  * @init:       Inits the transport backend. This usually involves creating a socket or something like that.
  * @shutdown:   Shuts down the transport backend
  * @connect:    Connects the transport backend, can do nothing if it's not connection oriented (i.e. UDP)
- * @disconnect: Disconnects the transport backend.
+ *              Return <0 to indicate failure
+ * @disconnect: Disconnects the transport backend. Return <0 to indicate failure.
  * @send:       Send some bytes
  * @recv:       Recv some bytes
  * @getsock:    Returns the socket fd, if supported by this transport. Otherwise returns -1
@@ -123,6 +122,7 @@ typedef struct t9p_transport
   t9p_get_sock_t getsock;
   t9p_reconnect_t reconnect;
   t9p_data_avail_t avail;
+  t9p_batch_t batch;
 } t9p_transport_t;
 
 /**


### PR DESCRIPTION
Adds a new method to the I/O abstraction layer called 'batch' that just enables/disables request batching. This is only needed when we send header data and body data separately. (See comments on #26). Nagle's algorithm is not sufficient for whatever reason here, at least for the legacy 4.4BSD derived network stack.

See below for performance benchmarks run with this change. These results should be the same as with #26, except without the caveats impacting `t9p_readdir` performance.

<img width="908" height="674" alt="image" src="https://github.com/user-attachments/assets/539ed823-7eb8-4f3a-8e60-ee9e6b2b5d8a" />

<img width="1174" height="838" alt="image" src="https://github.com/user-attachments/assets/aca41c24-3ad0-4464-9d13-3a36e30408a0" />

