### PR TITLE
Logging and memory usage improvements

### DIFF
--- a/src/t9p.c
+++ b/src/t9p.c
@@ -98,7 +98,11 @@
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 
-#define ERRLOG(...) fprintf(stderr, __VA_ARGS__)
+#define ERRLOG(...) do { \
+  fprintf(stderr, "%s: ", __FUNCTION__); \
+  fprintf(stderr, __VA_ARGS__); \
+} while (0)
+
 #define LOG(_context, _level, ...)                                                                 \
   if (_context && _context->opts.log_level <= _level) {                                            \
     fprintf(stderr, __VA_ARGS__);                                                                  \
@@ -962,7 +966,10 @@ t9p_opts_init(struct t9p_opts* opts)
 
 t9p_context_t*
 t9p_init(
-  t9p_transport_t* transport, const t9p_opts_t* opts, const char* apath, const char* addr,
+  t9p_transport_t* transport,
+  const t9p_opts_t* opts,
+  const char* apath,
+  const char* addr,
   const char* mntpoint
 )
 {
@@ -1053,7 +1060,7 @@ t9p_init(
 
   /** Attach to the root fs */
   if (t9p__attach_root(c) < 0) {
-    ERRLOG("Connected to %s failed\n", addr);
+    ERRLOG("Connection to %s failed\n", addr);
     transport->disconnect(c->conn);
     transport->shutdown(c->conn);
     mutex_unlock(c->socket_lock);
@@ -1071,6 +1078,7 @@ t9p_init(
 
   c->thr_run = 1;
   if (!(c->io_thread = thread_create(proc, c, c->opts.prio))) {
+    ERRLOG("Failed to create I/O task\n");
     t9p_shutdown(c);
     return NULL;
   }

--- a/src/t9p.c
+++ b/src/t9p.c
@@ -401,8 +401,8 @@ struct trans_node
 /**
  * Init the transaction queue
  */
-int
-tr_pool_init(struct trans_pool* q, uint32_t num)
+static int
+tr_pool_init(struct trans_pool* q, uint32_t num, bool threaded)
 {
   memset(q, 0, sizeof(*q));
 
@@ -410,9 +410,12 @@ tr_pool_init(struct trans_pool* q, uint32_t num)
   if (!q->queue)
     return -1;
 
-  if (!(q->recv_ev = event_create())) {
-    msg_queue_destroy(q->queue);
-    return -1;
+  /* if running in threaded mode, we need the per-transaction events */
+  if (threaded) {
+    if (!(q->recv_ev = event_create())) {
+      msg_queue_destroy(q->queue);
+      return -1;
+    }
   }
 
   if (!(q->guard = mutex_create())) {
@@ -1042,7 +1045,7 @@ t9p_init(
   if (opts->mode == T9P_THREAD_MODE_NONE)
     max_trans = 16;
 
-  if (tr_pool_init(&c->trans_pool, max_trans) < 0) {
+  if (tr_pool_init(&c->trans_pool, max_trans, opts->mode != T9P_THREAD_MODE_NONE) < 0) {
     ERRLOG("Unable to create transaction pool\n");
     goto error_post_fhl;
   }


### PR DESCRIPTION
* Bump rtems-tools
* Improve error logging in t9p_init
* Skip allocating events for transactions when these are not needed (i.e. thread mode disabled). Helps us save a bit of memory.