### PR TITLE
Misc fixes

### DIFF
--- a/src/t9p.c
+++ b/src/t9p.c
@@ -828,7 +828,12 @@ t9p__attach_root(struct t9p_context* c)
   }
 
   if (t9p__iserror(&com)) {
-    ERROR(c, "Rattach failed");
+    struct Rlerror err;
+    if (decode_Rlerror(&err, packetBuf, read) < 0) {
+      ERROR(c, "Rattach failed: Invalid response\n");
+    } else {
+      ERROR(c, "Rattach failed: %s\n", t9p__strerror(err.ecode));
+    }
     goto error;
   }
 

--- a/src/t9p_rtems.c
+++ b/src/t9p_rtems.c
@@ -419,18 +419,22 @@ p9Mount(const char* ip, const char* srvpath, const char* mntpt, const char* othe
   char opts[128];
   *opts = 0;
 
-  const char* p = strpbrk(ip, "@");
-  if (p) {
+  const char* apath = strpbrk(ip, "@");
+  if (apath) {
     char uid[32], gid[32];
     sscanf(ip, "%[^.].%[^@]%*s", uid, gid);
     snprintf(opts, sizeof(opts), "uid=%s,gid=%s", uid, gid);
+    apath++; /* skip the @ */
+  } else {
+    apath = ip; /* just use the ip directly */
   }
 
-  if (*opts && otheropts) {
-    strcat(opts, ",");
+  if (otheropts) {
+    if (*opts)
+      strcat(opts, ",");
     strcat(opts, otheropts);
   }
-  
+
   /* Check if they want to enable tracing */
   if (strstr(otheropts, "trace")) {
     s_do_trace = 1;
@@ -448,7 +452,7 @@ p9Mount(const char* ip, const char* srvpath, const char* mntpt, const char* othe
   printf("Mounting %s at %s with opts '%s'\n", srvpath, mntpt, opts);
 
   char mnt[512];
-  snprintf(mnt, sizeof(mnt), "%s:%s", p+1, srvpath);
+  snprintf(mnt, sizeof(mnt), "%s:%s", apath, srvpath);
   printf("mnt=%s, mtpt=%s\n", mnt, mntpt);
 
   int r = mount(mnt, mntpt, RTEMS_FILESYSTEM_TYPE_9P, 0, opts);


### PR DESCRIPTION
* `p9Mount` was not behaving correctly when no uid.gid string was passed. It wasn't crashing, but only because it was reading `p+1` when `p=NULL`, and `0x1` is unfortunately a valid memory address on most RTEMS systems.
* Print Rlerror code when Rattach fails, just for help debugging.